### PR TITLE
bug: fix Uncaught ReferenceError: global is not defined

### DIFF
--- a/src/Nova.jsx
+++ b/src/Nova.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { v4 } from 'uuid';
 
-const { window, CustomEvent, document } = global;
+const { window, CustomEvent, document } = globalThis;
 
 class Nova extends Component {
   constructor(props) {


### PR DESCRIPTION
<img width="556" alt="image" src="https://user-images.githubusercontent.com/98843967/205299004-5fd3a673-e32a-45fa-94c0-fe3b344de00f.png">
  
  
Global is not accessible in browser environment with vite.
This will fix the issue with any system as globalThis will resolve with any system.